### PR TITLE
Add missing runtime dependency and opt out of sandboxing

### DIFF
--- a/harbour-obdfish.desktop
+++ b/harbour-obdfish.desktop
@@ -5,4 +5,5 @@ Icon=harbour-obdfish
 Exec=harbour-obdfish
 Name=OBDFish
 Name[de]=OBDFish
-
+[X-Sailjail]
+Sandboxing=Disabled

--- a/rpm/harbour-obdfish.yaml
+++ b/rpm/harbour-obdfish.yaml
@@ -37,6 +37,7 @@ PkgConfigBR:
 # Runtime dependencies which are not automatically detected
 Requires:
   - sailfishsilica-qt5 >= 0.10.9 
+  - qt5-qtconnectivity-qtbluetooth
 
 # All installed files
 Files:


### PR DESCRIPTION
Thank you for keeping this app alive, hope opting out of sandboxing won't cause any problems on older OS versions.